### PR TITLE
Add SoftWire (software I2C master) for CH573

### DIFF
--- a/libraries/SoftWire/examples/i2c_scanner_soft/i2c_scanner_soft.ino
+++ b/libraries/SoftWire/examples/i2c_scanner_soft/i2c_scanner_soft.ino
@@ -1,0 +1,37 @@
+#include <SoftWire.h>
+#include <SimpleUsbSerial.h>
+
+void setup() {
+  SerialUSB.begin(115200);
+  while (!SerialUSB) delay(10);
+
+  SerialUSB.println("SoftWire I2C Scanner");
+  WireSW.begin();
+  WireSW.setClock(100000);
+}
+
+void loop() {
+  int found = 0;
+  SerialUSB.println("Scanning...");
+
+  for (uint8_t addr = 8; addr < 127; addr++) {
+    WireSW.beginTransmission(addr);
+    uint8_t err = WireSW.endTransmission();
+    if (err == 0) {
+      SerialUSB.print("  0x");
+      if (addr < 16) SerialUSB.print("0");
+      SerialUSB.println(addr, HEX);
+      found++;
+    }
+    delay(1);
+  }
+
+  if (found == 0) {
+    SerialUSB.println("  No devices found");
+  } else {
+    SerialUSB.print("Total: ");
+    SerialUSB.println(found);
+  }
+  SerialUSB.println();
+  delay(5000);
+}

--- a/libraries/SoftWire/examples/register_rw_soft/register_rw_soft.ino
+++ b/libraries/SoftWire/examples/register_rw_soft/register_rw_soft.ino
@@ -1,0 +1,56 @@
+#include <SoftWire.h>
+#include <SimpleUsbSerial.h>
+
+#define SENSOR_ADDR 0x68
+#define WHO_AM_I_REG 0x75
+
+bool writeRegister8(uint8_t addr, uint8_t reg, uint8_t value)
+{
+  WireSW.beginTransmission(addr);
+  WireSW.write(reg);
+  WireSW.write(value);
+  return (WireSW.endTransmission() == 0);
+}
+
+bool readRegister8(uint8_t addr, uint8_t reg, uint8_t *value)
+{
+  if (value == nullptr) {
+    return false;
+  }
+
+  uint8_t read = WireSW.requestFrom(addr, (uint8_t)1, (uint32_t)reg, (uint8_t)1, (uint8_t)true);
+  if (read != 1 || !WireSW.available()) {
+    return false;
+  }
+
+  *value = (uint8_t)WireSW.read();
+  return true;
+}
+
+void setup()
+{
+  SerialUSB.begin(115200);
+  while (!SerialUSB) delay(10);
+
+  SerialUSB.println("SoftWire register read/write example");
+  SerialUSB.println("Default pins: SDA=PB12, SCL=PB13");
+
+  WireSW.begin();
+  WireSW.setClock(100000);
+
+  uint8_t whoami = 0;
+  if (readRegister8(SENSOR_ADDR, WHO_AM_I_REG, &whoami)) {
+    SerialUSB.print("WHO_AM_I: 0x");
+    SerialUSB.println(whoami, HEX);
+  } else {
+    SerialUSB.println("Read failed (check sensor/pins/pullups)");
+  }
+
+  // Example write helper usage (disabled by default):
+  // writeRegister8(SENSOR_ADDR, 0x6B, 0x00);
+}
+
+void loop()
+{
+  delay(1000);
+}

--- a/libraries/SoftWire/keywords.txt
+++ b/libraries/SoftWire/keywords.txt
@@ -1,0 +1,12 @@
+SoftWire	KEYWORD1
+WireSW	KEYWORD2
+begin	KEYWORD2
+beginTransmission	KEYWORD2
+endTransmission	KEYWORD2
+requestFrom	KEYWORD2
+setClock	KEYWORD2
+read	KEYWORD2
+available	KEYWORD2
+peek	KEYWORD2
+flush	KEYWORD2
+write	KEYWORD2

--- a/libraries/SoftWire/library.properties
+++ b/libraries/SoftWire/library.properties
@@ -1,0 +1,9 @@
+name=SoftWire
+version=1.0.0
+author=Electronic Cats, based on Arduino Wire semantics
+maintainer=Electronic Cats
+sentence=Software I2C (bit-bang) master library for CH573 with Wire-like API.
+paragraph=Provides begin, transmission, requestFrom and stream methods without modifying the Wire library. This version targets CH573.
+category=Communication
+url=https://github.com/electroniccats/arduino_core_ch32
+architectures=ch32v

--- a/libraries/SoftWire/src/SoftWire.cpp
+++ b/libraries/SoftWire/src/SoftWire.cpp
@@ -1,0 +1,772 @@
+/*
+  SoftWire.cpp - Software I2C (bit-bang) library for CH573
+*/
+
+extern "C" {
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+}
+
+#include "SoftWire.h"
+#include "core_debug.h"
+
+#if !defined(CH573)
+#warning "SoftWire currently supports CH573 only. Methods are stubbed on other chips."
+#endif
+
+SoftWire WireSW;
+
+SoftWire::SoftWire()
+  : rxBuffer(nullptr),
+    rxBufferAllocated(0),
+    rxBufferIndex(0),
+    rxBufferLength(0),
+    txAddress(0),
+    txBuffer(nullptr),
+    txBufferAllocated(0),
+    txDataSize(0),
+    transmitting(0),
+    _sdaPin(SOFTWIRE_DEFAULT_SDA),
+    _sclPin(SOFTWIRE_DEFAULT_SCL),
+    _delayUs(5),
+    _stretchTimeoutMs(10),
+    _enabled(false),
+    _started(false),
+    _warnedUnsupported(false)
+{
+}
+
+SoftWire::SoftWire(uint32_t sda, uint32_t scl)
+  : rxBuffer(nullptr),
+    rxBufferAllocated(0),
+    rxBufferIndex(0),
+    rxBufferLength(0),
+    txAddress(0),
+    txBuffer(nullptr),
+    txBufferAllocated(0),
+    txDataSize(0),
+    transmitting(0),
+    _sdaPin(sda),
+    _sclPin(scl),
+    _delayUs(5),
+    _stretchTimeoutMs(10),
+    _enabled(false),
+    _started(false),
+    _warnedUnsupported(false)
+{
+}
+
+void SoftWire::setSDA(uint32_t sda)
+{
+  _sdaPin = sda;
+}
+
+void SoftWire::setSCL(uint32_t scl)
+{
+  _sclPin = scl;
+}
+
+void SoftWire::setSDA(PinName sda)
+{
+  uint32_t pin = pinNametoDigitalPin(sda);
+  if (pin < NUM_DIGITAL_PINS) {
+    _sdaPin = pin;
+  }
+}
+
+void SoftWire::setSCL(PinName scl)
+{
+  uint32_t pin = pinNametoDigitalPin(scl);
+  if (pin < NUM_DIGITAL_PINS) {
+    _sclPin = pin;
+  }
+}
+
+void SoftWire::begin(uint32_t sda, uint32_t scl)
+{
+  _sdaPin = sda;
+  _sclPin = scl;
+  begin();
+}
+
+void SoftWire::begin()
+{
+  rxBufferIndex = 0;
+  rxBufferLength = 0;
+  resetRxBuffer();
+
+  txAddress = 0;
+  txDataSize = 0;
+  transmitting = 0;
+  resetTxBuffer();
+
+#if defined(CH573)
+  if ((_sdaPin >= NUM_DIGITAL_PINS) || (_sclPin >= NUM_DIGITAL_PINS)) {
+    _enabled = false;
+    return;
+  }
+
+  _enabled = true;
+  _started = false;
+
+  setClock(100000);
+
+  pinMode(_sdaPin, INPUT_PULLUP);
+  pinMode(_sclPin, INPUT_PULLUP);
+
+  recoverBus();
+#else
+  _enabled = false;
+  if (!_warnedUnsupported) {
+    core_debug("SoftWire: this MCU is not supported. CH573 only.\n");
+    _warnedUnsupported = true;
+  }
+#endif
+}
+
+void SoftWire::end()
+{
+#if defined(CH573)
+  if (_enabled && _started) {
+    (void)stopCondition();
+  }
+  if (_sdaPin < NUM_DIGITAL_PINS) {
+    pinMode(_sdaPin, INPUT);
+  }
+  if (_sclPin < NUM_DIGITAL_PINS) {
+    pinMode(_sclPin, INPUT);
+  }
+#endif
+
+  _enabled = false;
+  _started = false;
+
+  free(txBuffer);
+  txBuffer = nullptr;
+  txBufferAllocated = 0;
+  txDataSize = 0;
+
+  free(rxBuffer);
+  rxBuffer = nullptr;
+  rxBufferAllocated = 0;
+  rxBufferLength = 0;
+  rxBufferIndex = 0;
+
+  transmitting = 0;
+}
+
+void SoftWire::setClock(uint32_t frequency)
+{
+#if defined(CH573)
+  if (frequency < 1000U) {
+    frequency = 1000U;
+  }
+  if (frequency > 400000U) {
+    frequency = 400000U;
+  }
+
+  uint32_t halfPeriodUs = 500000UL / frequency;
+  _delayUs = (uint16_t)halfPeriodUs;
+#else
+  (void)frequency;
+#endif
+}
+
+void SoftWire::beginTransmission(uint8_t address)
+{
+  transmitting = 1;
+  txAddress = (uint8_t)(address & 0x7F);
+  txDataSize = 0;
+}
+
+void SoftWire::beginTransmission(int address)
+{
+  beginTransmission((uint8_t)address);
+}
+
+uint8_t SoftWire::endTransmission(void)
+{
+  return endTransmission((uint8_t)true);
+}
+
+uint8_t SoftWire::endTransmission(uint8_t sendStop)
+{
+  uint8_t ret = 4;
+
+  if (!_enabled || (transmitting == 0)) {
+    return ret;
+  }
+
+  SoftWireStatus status = writeTransfer(txAddress, txBuffer, txDataSize, sendStop != 0);
+
+  switch (status) {
+    case SW_OK:
+      ret = 0;
+      break;
+    case SW_DATA_TOO_LONG:
+      ret = 1;
+      break;
+    case SW_NACK_ADDR:
+      ret = 2;
+      break;
+    case SW_NACK_DATA:
+      ret = 3;
+      break;
+    case SW_NOT_SUPPORTED:
+    case SW_ERROR:
+    case SW_TIMEOUT:
+    case SW_BUSY:
+    default:
+      ret = 4;
+      break;
+  }
+
+  resetTxBuffer();
+  txDataSize = 0;
+  transmitting = 0;
+
+  return ret;
+}
+
+uint8_t SoftWire::requestFrom(uint8_t address, uint8_t quantity)
+{
+  return requestFrom(address, quantity, (uint8_t)true);
+}
+
+uint8_t SoftWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop)
+{
+  return requestFrom(address, quantity, (uint32_t)0, (uint8_t)0, sendStop);
+}
+
+uint8_t SoftWire::requestFrom(uint8_t address, size_t quantity, bool sendStop)
+{
+  return requestFrom(address, (uint8_t)quantity, (uint8_t)sendStop);
+}
+
+uint8_t SoftWire::requestFrom(uint8_t address, uint8_t quantity,
+                              uint32_t iaddress, uint8_t isize, uint8_t sendStop)
+{
+  uint8_t read = 0;
+
+  if ((!_enabled) || (quantity == 0)) {
+    return 0;
+  }
+
+  if (!allocateRxBuffer(quantity) || (rxBuffer == nullptr) || (rxBufferAllocated < quantity)) {
+    return 0;
+  }
+
+  if (isize > 0) {
+    beginTransmission(address);
+
+    if (isize > 3) {
+      isize = 3;
+    }
+
+    while (isize-- > 0) {
+      write((uint8_t)(iaddress >> (isize * 8)));
+    }
+
+    if (endTransmission((uint8_t)false) != 0) {
+      rxBufferIndex = 0;
+      rxBufferLength = 0;
+      return 0;
+    }
+  }
+
+  SoftWireStatus status = readTransfer((uint8_t)(address & 0x7F), rxBuffer, quantity, sendStop != 0);
+  if (status == SW_OK) {
+    read = quantity;
+  }
+
+  rxBufferIndex = 0;
+  rxBufferLength = read;
+
+  return read;
+}
+
+uint8_t SoftWire::requestFrom(int address, int quantity)
+{
+  return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)true);
+}
+
+uint8_t SoftWire::requestFrom(int address, int quantity, int sendStop)
+{
+  return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)sendStop);
+}
+
+size_t SoftWire::write(uint8_t data)
+{
+  if (!transmitting) {
+    return 0;
+  }
+
+  if (allocateTxBuffer(txDataSize + 1) == 0) {
+    return 0;
+  }
+
+  txBuffer[txDataSize] = data;
+  txDataSize++;
+
+  return 1;
+}
+
+size_t SoftWire::write(const uint8_t *data, size_t quantity)
+{
+  if ((!transmitting) || (data == nullptr) || (quantity == 0)) {
+    return 0;
+  }
+
+  if (allocateTxBuffer(txDataSize + quantity) == 0) {
+    return 0;
+  }
+
+  memcpy(txBuffer + txDataSize, data, quantity);
+  txDataSize += quantity;
+
+  return quantity;
+}
+
+int SoftWire::available(void)
+{
+  return (int)(rxBufferLength - rxBufferIndex);
+}
+
+int SoftWire::read(void)
+{
+  int value = -1;
+
+  if (rxBufferIndex < rxBufferLength) {
+    value = rxBuffer[rxBufferIndex];
+    rxBufferIndex++;
+  }
+
+  return value;
+}
+
+int SoftWire::peek(void)
+{
+  int value = -1;
+
+  if (rxBufferIndex < rxBufferLength) {
+    value = rxBuffer[rxBufferIndex];
+  }
+
+  return value;
+}
+
+void SoftWire::flush(void)
+{
+}
+
+bool SoftWire::allocateRxBuffer(size_t length)
+{
+  if (length == 0) {
+    return true;
+  }
+
+  if (rxBufferAllocated < length) {
+    if (length < SOFTWIRE_BUFFER_LENGTH) {
+      length = SOFTWIRE_BUFFER_LENGTH;
+    }
+
+    uint8_t *tmp = (uint8_t *)realloc(rxBuffer, length * sizeof(uint8_t));
+    if (tmp != nullptr) {
+      rxBuffer = tmp;
+      rxBufferAllocated = (uint16_t)length;
+    } else {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+size_t SoftWire::allocateTxBuffer(size_t length)
+{
+  size_t ret = length;
+
+  if (length > SOFTWIRE_MAX_TX_BUFF_LENGTH) {
+    ret = 0;
+  } else if (txBufferAllocated < length) {
+    if (length < SOFTWIRE_BUFFER_LENGTH) {
+      length = SOFTWIRE_BUFFER_LENGTH;
+    }
+
+    uint8_t *tmp = (uint8_t *)realloc(txBuffer, length * sizeof(uint8_t));
+    if (tmp != nullptr) {
+      txBuffer = tmp;
+      txBufferAllocated = (uint16_t)length;
+    } else {
+      ret = 0;
+    }
+  }
+
+  return ret;
+}
+
+void SoftWire::resetRxBuffer(void)
+{
+  if (rxBuffer != nullptr) {
+    memset(rxBuffer, 0, rxBufferAllocated);
+  }
+}
+
+void SoftWire::resetTxBuffer(void)
+{
+  if (txBuffer != nullptr) {
+    memset(txBuffer, 0, txBufferAllocated);
+  }
+}
+
+void SoftWire::recoverBus(void)
+{
+#if defined(CH573)
+  if (!_enabled) {
+    return;
+  }
+
+  sdaHigh();
+  (void)sclHighWithStretch();
+
+  if (sdaRead() == LOW) {
+    for (int i = 0; i < 20; i++) {
+      sclLow();
+      delayMicroseconds(10);
+      if (!sclHighWithStretch()) {
+        break;
+      }
+      delayMicroseconds(10);
+      if (sdaRead() == HIGH) {
+        break;
+      }
+    }
+    (void)stopCondition();
+  }
+#endif
+}
+
+void SoftWire::sdaHigh(void)
+{
+#if defined(CH573)
+  pinMode(_sdaPin, INPUT_PULLUP);
+#endif
+}
+
+void SoftWire::sdaLow(void)
+{
+#if defined(CH573)
+  pinMode(_sdaPin, OUTPUT);
+  digitalWrite(_sdaPin, LOW);
+#endif
+}
+
+bool SoftWire::sclHighWithStretch(void)
+{
+#if defined(CH573)
+  pinMode(_sclPin, INPUT_PULLUP);
+
+  uint32_t start = millis();
+  while (digitalRead(_sclPin) == LOW) {
+    if ((millis() - start) > _stretchTimeoutMs) {
+      return false;
+    }
+  }
+
+  return true;
+#else
+  return false;
+#endif
+}
+
+void SoftWire::sclLow(void)
+{
+#if defined(CH573)
+  pinMode(_sclPin, OUTPUT);
+  digitalWrite(_sclPin, LOW);
+#endif
+}
+
+uint8_t SoftWire::sdaRead(void)
+{
+#if defined(CH573)
+  return (uint8_t)digitalRead(_sdaPin);
+#else
+  return 1;
+#endif
+}
+
+void SoftWire::i2cDelay(void)
+{
+#if defined(CH573)
+  delayMicroseconds(_delayUs);
+#endif
+}
+
+bool SoftWire::startCondition(void)
+{
+#if defined(CH573)
+  if (!_enabled) {
+    return false;
+  }
+
+  sdaHigh();
+  i2cDelay();
+
+  if (!sclHighWithStretch()) {
+    return false;
+  }
+  i2cDelay();
+
+  sdaLow();
+  i2cDelay();
+
+  sclLow();
+  i2cDelay();
+
+  _started = true;
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool SoftWire::stopCondition(void)
+{
+#if defined(CH573)
+  if (!_enabled) {
+    return false;
+  }
+
+  sdaLow();
+  i2cDelay();
+
+  if (!sclHighWithStretch()) {
+    return false;
+  }
+  i2cDelay();
+
+  sdaHigh();
+  i2cDelay();
+
+  _started = false;
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool SoftWire::writeBit(uint8_t bit)
+{
+#if defined(CH573)
+  if (bit) {
+    sdaHigh();
+  } else {
+    sdaLow();
+  }
+  i2cDelay();
+
+  if (!sclHighWithStretch()) {
+    return false;
+  }
+  i2cDelay();
+
+  sclLow();
+  i2cDelay();
+
+  return true;
+#else
+  (void)bit;
+  return false;
+#endif
+}
+
+bool SoftWire::readBit(uint8_t *bit)
+{
+#if defined(CH573)
+  sdaHigh();
+  i2cDelay();
+
+  if (!sclHighWithStretch()) {
+    return false;
+  }
+  i2cDelay();
+
+  *bit = sdaRead();
+
+  sclLow();
+  i2cDelay();
+
+  return true;
+#else
+  if (bit != nullptr) {
+    *bit = 1;
+  }
+  return false;
+#endif
+}
+
+SoftWire::SoftWireStatus SoftWire::writeByte(uint8_t value, bool *acked)
+{
+#if defined(CH573)
+  for (uint8_t i = 0; i < 8; i++) {
+    if (!writeBit((uint8_t)((value & 0x80U) != 0U))) {
+      return SW_TIMEOUT;
+    }
+    value <<= 1;
+  }
+
+  uint8_t nackBit = 1;
+  if (!readBit(&nackBit)) {
+    return SW_TIMEOUT;
+  }
+
+  if (acked != nullptr) {
+    *acked = (nackBit == 0U);
+  }
+
+  return SW_OK;
+#else
+  (void)value;
+  if (acked != nullptr) {
+    *acked = false;
+  }
+  return SW_NOT_SUPPORTED;
+#endif
+}
+
+SoftWire::SoftWireStatus SoftWire::readByte(uint8_t *value, bool ack)
+{
+#if defined(CH573)
+  uint8_t out = 0;
+  uint8_t bit = 0;
+
+  for (uint8_t i = 0; i < 8; i++) {
+    out <<= 1;
+    if (!readBit(&bit)) {
+      return SW_TIMEOUT;
+    }
+    out |= (uint8_t)(bit & 0x01U);
+  }
+
+  if (!writeBit((uint8_t)(ack ? 0U : 1U))) {
+    return SW_TIMEOUT;
+  }
+
+  if (value != nullptr) {
+    *value = out;
+  }
+
+  return SW_OK;
+#else
+  (void)ack;
+  if (value != nullptr) {
+    *value = 0;
+  }
+  return SW_NOT_SUPPORTED;
+#endif
+}
+
+SoftWire::SoftWireStatus SoftWire::writeTransfer(uint8_t address7, const uint8_t *data,
+                                                 uint16_t size, bool sendStop)
+{
+#if defined(CH573)
+  if (!_enabled) {
+    return SW_ERROR;
+  }
+
+  if (!startCondition()) {
+    return SW_TIMEOUT;
+  }
+
+  bool acked = false;
+  SoftWireStatus status = writeByte((uint8_t)((address7 << 1) & 0xFEU), &acked);
+  if (status != SW_OK) {
+    (void)stopCondition();
+    return status;
+  }
+  if (!acked) {
+    (void)stopCondition();
+    return SW_NACK_ADDR;
+  }
+
+  for (uint16_t i = 0; i < size; i++) {
+    status = writeByte(data[i], &acked);
+    if (status != SW_OK) {
+      (void)stopCondition();
+      return status;
+    }
+    if (!acked) {
+      (void)stopCondition();
+      return SW_NACK_DATA;
+    }
+  }
+
+  if (sendStop) {
+    if (!stopCondition()) {
+      return SW_TIMEOUT;
+    }
+  }
+
+  return SW_OK;
+#else
+  (void)address7;
+  (void)data;
+  (void)size;
+  (void)sendStop;
+  return SW_NOT_SUPPORTED;
+#endif
+}
+
+SoftWire::SoftWireStatus SoftWire::readTransfer(uint8_t address7, uint8_t *data,
+                                                uint16_t size, bool sendStop)
+{
+#if defined(CH573)
+  if (!_enabled) {
+    return SW_ERROR;
+  }
+
+  if ((size > 0) && (data == nullptr)) {
+    return SW_ERROR;
+  }
+
+  if (!startCondition()) {
+    return SW_TIMEOUT;
+  }
+
+  bool acked = false;
+  SoftWireStatus status = writeByte((uint8_t)((address7 << 1) | 0x01U), &acked);
+  if (status != SW_OK) {
+    (void)stopCondition();
+    return status;
+  }
+  if (!acked) {
+    (void)stopCondition();
+    return SW_NACK_ADDR;
+  }
+
+  for (uint16_t i = 0; i < size; i++) {
+    bool ack = (i < (uint16_t)(size - 1));
+    status = readByte(&data[i], ack);
+    if (status != SW_OK) {
+      (void)stopCondition();
+      return status;
+    }
+  }
+
+  if (sendStop) {
+    if (!stopCondition()) {
+      return SW_TIMEOUT;
+    }
+  }
+
+  return SW_OK;
+#else
+  (void)address7;
+  (void)data;
+  (void)size;
+  (void)sendStop;
+  return SW_NOT_SUPPORTED;
+#endif
+}

--- a/libraries/SoftWire/src/SoftWire.h
+++ b/libraries/SoftWire/src/SoftWire.h
@@ -1,0 +1,147 @@
+/*
+  SoftWire.h - Software I2C (bit-bang) library for CH573
+
+  This library intentionally does not modify Wire.
+  It provides a Wire-like master API using GPIO bit-banging.
+*/
+
+#ifndef SoftWire_h
+#define SoftWire_h
+
+#include "Stream.h"
+#include "Arduino.h"
+
+#define SOFTWIRE_BUFFER_LENGTH 32
+#if !defined(SOFTWIRE_MAX_TX_BUFF_LENGTH)
+  #define SOFTWIRE_MAX_TX_BUFF_LENGTH 1024U
+#endif
+
+#if defined(CH573)
+  #define SOFTWIRE_DEFAULT_SDA PB12
+  #define SOFTWIRE_DEFAULT_SCL PB13
+#else
+  #define SOFTWIRE_DEFAULT_SDA PNUM_NOT_DEFINED
+  #define SOFTWIRE_DEFAULT_SCL PNUM_NOT_DEFINED
+#endif
+
+class SoftWire : public Stream {
+  public:
+    SoftWire();
+    SoftWire(uint32_t sda, uint32_t scl);
+
+    void setSDA(uint32_t sda);
+    void setSCL(uint32_t scl);
+    void setSDA(PinName sda);
+    void setSCL(PinName scl);
+
+    void begin();
+    void begin(uint32_t sda, uint32_t scl);
+    void end();
+
+    void setClock(uint32_t frequency);
+
+    void beginTransmission(uint8_t address);
+    void beginTransmission(int address);
+
+    uint8_t endTransmission(void);
+    uint8_t endTransmission(uint8_t sendStop);
+
+    uint8_t requestFrom(uint8_t address, uint8_t quantity);
+    uint8_t requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop);
+    uint8_t requestFrom(uint8_t address, size_t quantity, bool sendStop);
+    uint8_t requestFrom(uint8_t address, uint8_t quantity,
+                        uint32_t iaddress, uint8_t isize, uint8_t sendStop);
+    uint8_t requestFrom(int address, int quantity);
+    uint8_t requestFrom(int address, int quantity, int sendStop);
+
+    virtual size_t write(uint8_t data);
+    virtual size_t write(const uint8_t *data, size_t quantity);
+
+    virtual int available(void);
+    virtual int read(void);
+    virtual int peek(void);
+    virtual void flush(void);
+
+    inline size_t write(unsigned long n)
+    {
+      return write((uint8_t)n);
+    }
+    inline size_t write(long n)
+    {
+      return write((uint8_t)n);
+    }
+    inline size_t write(unsigned int n)
+    {
+      return write((uint8_t)n);
+    }
+    inline size_t write(int n)
+    {
+      return write((uint8_t)n);
+    }
+
+    using Print::write;
+
+  private:
+    enum SoftWireStatus {
+      SW_OK = 0,
+      SW_DATA_TOO_LONG,
+      SW_NACK_ADDR,
+      SW_NACK_DATA,
+      SW_ERROR,
+      SW_TIMEOUT,
+      SW_BUSY,
+      SW_NOT_SUPPORTED
+    };
+
+    uint8_t *rxBuffer;
+    uint16_t rxBufferAllocated;
+    uint16_t rxBufferIndex;
+    uint16_t rxBufferLength;
+
+    uint8_t txAddress;
+    uint8_t *txBuffer;
+    uint16_t txBufferAllocated;
+    uint16_t txDataSize;
+
+    uint8_t transmitting;
+
+    uint32_t _sdaPin;
+    uint32_t _sclPin;
+    uint16_t _delayUs;
+    uint16_t _stretchTimeoutMs;
+    bool _enabled;
+    bool _started;
+    bool _warnedUnsupported;
+
+    bool allocateRxBuffer(size_t length);
+    size_t allocateTxBuffer(size_t length);
+    void resetRxBuffer(void);
+    void resetTxBuffer(void);
+
+    void recoverBus(void);
+
+    void sdaHigh(void);
+    void sdaLow(void);
+    bool sclHighWithStretch(void);
+    void sclLow(void);
+    uint8_t sdaRead(void);
+    void i2cDelay(void);
+
+    bool startCondition(void);
+    bool stopCondition(void);
+
+    bool writeBit(uint8_t bit);
+    bool readBit(uint8_t *bit);
+
+    SoftWireStatus writeByte(uint8_t value, bool *acked);
+    SoftWireStatus readByte(uint8_t *value, bool ack);
+
+    SoftWireStatus writeTransfer(uint8_t address7, const uint8_t *data,
+                                 uint16_t size, bool sendStop);
+    SoftWireStatus readTransfer(uint8_t address7, uint8_t *data,
+                                uint16_t size, bool sendStop);
+};
+
+extern SoftWire WireSW;
+
+#endif


### PR DESCRIPTION
## Summary
This PR adds a new `SoftWire` library that provides a Wire-like **master** API for CH573 using software I2C (bit-bang).

## Why
CH573 projects often need reliable I2C on custom pins and/or a fallback when hardware I2C is unavailable.  
The goal is to support this without risking regressions in the existing Wire core.

## What’s included
- New library: `libraries/SoftWire`
- Wire-like master API:
  - `begin()`, `begin(sda,scl)`, `end()`, `setClock()`
  - `beginTransmission()`, `endTransmission([sendStop])`
  - `requestFrom(...)` (including internal register address variant)
  - `read()`, `available()`, `peek()`, `write()`, `flush()`
- Default CH573 pins: `PB12` (SDA), `PB13` (SCL)
- Software open-drain behavior:
  - HIGH = `INPUT_PULLUP`
  - LOW = `OUTPUT + LOW`
- START/STOP/repeated-start, ACK/NACK handling
- `endTransmission()` return codes aligned with Wire (0..4)
- CH573-only implementation (`#if defined(CH573)`), clear unsupported stubs elsewhere
- Examples:
  - `i2c_scanner_soft` (SerialUSB)
  - `register_rw_soft`

## Robustness improvements
- Bus recovery on `begin()`
- Clock-stretch wait with timeout
- Early-exit in recovery loop when SDA is released
- Safer RX buffer allocation checks in `requestFrom()`
- `keywords.txt` completed (`available`, `peek`, `flush`)

## Validation
Compiled successfully with `arduino-cli`:
- CH573 + `SoftWire/examples/i2c_scanner_soft`
- CH573 + `SoftWire/examples/register_rw_soft`
- CH573 + base sketch (no SoftWire usage)
- CH32V00x + `Wire/examples/i2c_scanner`
- CH32V20x + `Wire/examples/i2c_scanner`

## Scope / non-goals
- Master mode only (no slave callbacks yet)
- Does not replace or modify existing `Wire` behavior