### PR TITLE
Add wlink as Upload Method for CH32 core

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repo adds the support of CH32 MCU in Arduino IDE.<br>
 The file includes:
 * [Arduino_Core_CH32](https://github.com/openwch/arduino_core_ch32):Public library files.
 * [openocd](https://github.com/openwch/openocd_wch):can directly use WCH-LINKE to download and debug wch chips.
+* [wlink](https://github.com/ch32-rs/wlink):optional WCH-Link uploader available from the Upload Method menu.
 * [riscv-none-embed-gcc](https://github.com/openwch/risc-none-embed-gcc):A toolchain that supports WCH custom half word and byte compression instruction extensions and hardware stack push/pop functions.
 
 ## How to use
@@ -24,6 +25,11 @@ Add the following link in the "*Additional Boards Managers URLs*" field:
 https://github.com/openwch/board_manager_files/raw/main/package_ch32v_index.json
 
 Then you can search for "**wch**" through the "**board manager**", find the installation package, and install it.
+
+After selecting a board, you can choose upload tool from `Tools > Upload method`:
+- `WCH-SWD` (default, OpenOCD based)
+- `WCH-ISP`
+- `WCH-Link (wlink)` (autodetects target chip)
 
 ## Supported boards
 
@@ -68,7 +74,7 @@ It will be a long-term support and maintenance project, unless we encounter forc
 
 ## OS support
 
-Adopting toolchain and openocd under [MRS](http://www.mounriver.com/), supporting HPE, custom byte and half-word compression extensions,"upload" via WCH_LINKE. 
+Adopting toolchain and openocd under [MRS](http://www.mounriver.com/), supporting HPE, custom byte and half-word compression extensions, with upload via WCH_LINKE, WCH-ISP, or WCH-Link (`wlink`). 
 
 **Most importantly, the version of Arduino IDE is 2.0+.**
 
@@ -113,5 +119,4 @@ please contact the **MRS team** for assistance through "*support@mounriver.com*"
 
 If you have any questions, you could contact me through the email "*yy@wch.cn*".
 Or you could [file an issue on GitHub](https://github.com/openwch/arduino_core_ch32/issues/new).
-
 

--- a/boards.txt
+++ b/boards.txt
@@ -46,10 +46,32 @@ CH573_EVT.menu.upload_method.swdMethod=WCH-SWD
 CH573_EVT.menu.upload_method.swdMethod.upload.protocol=
 CH573_EVT.menu.upload_method.swdMethod.upload.options=
 CH573_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
+CH573_EVT.menu.upload_method.swdMethod.upload.use_1200bps_touch=false
 CH573_EVT.menu.upload_method.ispMethod=WCH-ISP
 CH573_EVT.menu.upload_method.ispMethod.upload.protocol=
 CH573_EVT.menu.upload_method.ispMethod.upload.options=
 CH573_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
+CH573_EVT.menu.upload_method.ispMethod.upload.use_1200bps_touch=true
+CH573_EVT.menu.upload_method.wlinkMethod=WCH-Link (wlink)
+CH573_EVT.menu.upload_method.wlinkMethod.upload.protocol=
+CH573_EVT.menu.upload_method.wlinkMethod.upload.options=
+CH573_EVT.menu.upload_method.wlinkMethod.upload.tool=wlink
+CH573_EVT.menu.upload_method.wlinkMethod.upload.use_1200bps_touch=false
+CH573_EVT.menu.pnum.CH573.menu.upload_method.swdMethod=WCH-SWD
+CH573_EVT.menu.pnum.CH573.menu.upload_method.swdMethod.upload.protocol=
+CH573_EVT.menu.pnum.CH573.menu.upload_method.swdMethod.upload.options=
+CH573_EVT.menu.pnum.CH573.menu.upload_method.swdMethod.upload.tool=WCH_linkE
+CH573_EVT.menu.pnum.CH573.menu.upload_method.swdMethod.upload.use_1200bps_touch=false
+CH573_EVT.menu.pnum.CH573.menu.upload_method.ispMethod=WCH-ISP
+CH573_EVT.menu.pnum.CH573.menu.upload_method.ispMethod.upload.protocol=
+CH573_EVT.menu.pnum.CH573.menu.upload_method.ispMethod.upload.options=
+CH573_EVT.menu.pnum.CH573.menu.upload_method.ispMethod.upload.tool=wchisp
+CH573_EVT.menu.pnum.CH573.menu.upload_method.ispMethod.upload.use_1200bps_touch=true
+CH573_EVT.menu.pnum.CH573.menu.upload_method.wlinkMethod=WCH-Link (wlink)
+CH573_EVT.menu.pnum.CH573.menu.upload_method.wlinkMethod.upload.protocol=
+CH573_EVT.menu.pnum.CH573.menu.upload_method.wlinkMethod.upload.options=
+CH573_EVT.menu.pnum.CH573.menu.upload_method.wlinkMethod.upload.tool=wlink
+CH573_EVT.menu.pnum.CH573.menu.upload_method.wlinkMethod.upload.use_1200bps_touch=false
 
 # Optimizations
 CH573_EVT.menu.opt.osstd=Smallest (-Os default)
@@ -126,6 +148,22 @@ CH572_EVT.menu.upload_method.ispMethod=WCH-ISP
 CH572_EVT.menu.upload_method.ispMethod.upload.protocol=
 CH572_EVT.menu.upload_method.ispMethod.upload.options=
 CH572_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
+CH572_EVT.menu.upload_method.wlinkMethod=WCH-Link (wlink)
+CH572_EVT.menu.upload_method.wlinkMethod.upload.protocol=
+CH572_EVT.menu.upload_method.wlinkMethod.upload.options=
+CH572_EVT.menu.upload_method.wlinkMethod.upload.tool=wlink
+CH572_EVT.menu.pnum.CH572.menu.upload_method.swdMethod=WCH-SWD
+CH572_EVT.menu.pnum.CH572.menu.upload_method.swdMethod.upload.protocol=
+CH572_EVT.menu.pnum.CH572.menu.upload_method.swdMethod.upload.options=
+CH572_EVT.menu.pnum.CH572.menu.upload_method.swdMethod.upload.tool=WCH_linkE
+CH572_EVT.menu.pnum.CH572.menu.upload_method.ispMethod=WCH-ISP
+CH572_EVT.menu.pnum.CH572.menu.upload_method.ispMethod.upload.protocol=
+CH572_EVT.menu.pnum.CH572.menu.upload_method.ispMethod.upload.options=
+CH572_EVT.menu.pnum.CH572.menu.upload_method.ispMethod.upload.tool=wchisp
+CH572_EVT.menu.pnum.CH572.menu.upload_method.wlinkMethod=WCH-Link (wlink)
+CH572_EVT.menu.pnum.CH572.menu.upload_method.wlinkMethod.upload.protocol=
+CH572_EVT.menu.pnum.CH572.menu.upload_method.wlinkMethod.upload.options=
+CH572_EVT.menu.pnum.CH572.menu.upload_method.wlinkMethod.upload.tool=wlink
 
 # Optimizations
 CH572_EVT.menu.opt.osstd=Smallest (-Os default)
@@ -202,6 +240,22 @@ CH585_EVT.menu.upload_method.ispMethod=WCH-ISP
 CH585_EVT.menu.upload_method.ispMethod.upload.protocol=
 CH585_EVT.menu.upload_method.ispMethod.upload.options=
 CH585_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
+CH585_EVT.menu.upload_method.wlinkMethod=WCH-Link (wlink)
+CH585_EVT.menu.upload_method.wlinkMethod.upload.protocol=
+CH585_EVT.menu.upload_method.wlinkMethod.upload.options=
+CH585_EVT.menu.upload_method.wlinkMethod.upload.tool=wlink
+CH585_EVT.menu.pnum.CH585.menu.upload_method.swdMethod=WCH-SWD
+CH585_EVT.menu.pnum.CH585.menu.upload_method.swdMethod.upload.protocol=
+CH585_EVT.menu.pnum.CH585.menu.upload_method.swdMethod.upload.options=
+CH585_EVT.menu.pnum.CH585.menu.upload_method.swdMethod.upload.tool=WCH_linkE
+CH585_EVT.menu.pnum.CH585.menu.upload_method.ispMethod=WCH-ISP
+CH585_EVT.menu.pnum.CH585.menu.upload_method.ispMethod.upload.protocol=
+CH585_EVT.menu.pnum.CH585.menu.upload_method.ispMethod.upload.options=
+CH585_EVT.menu.pnum.CH585.menu.upload_method.ispMethod.upload.tool=wchisp
+CH585_EVT.menu.pnum.CH585.menu.upload_method.wlinkMethod=WCH-Link (wlink)
+CH585_EVT.menu.pnum.CH585.menu.upload_method.wlinkMethod.upload.protocol=
+CH585_EVT.menu.pnum.CH585.menu.upload_method.wlinkMethod.upload.options=
+CH585_EVT.menu.pnum.CH585.menu.upload_method.wlinkMethod.upload.tool=wlink
 
 # Optimizations
 CH585_EVT.menu.opt.osstd=Smallest (-Os default)
@@ -278,6 +332,10 @@ CH32V00x_EVT.menu.upload_method.ispMethod=WCH-ISP
 CH32V00x_EVT.menu.upload_method.ispMethod.upload.protocol=
 CH32V00x_EVT.menu.upload_method.ispMethod.upload.options=
 CH32V00x_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
+CH32V00x_EVT.menu.upload_method.wlinkMethod=WCH-Link (wlink)
+CH32V00x_EVT.menu.upload_method.wlinkMethod.upload.protocol=
+CH32V00x_EVT.menu.upload_method.wlinkMethod.upload.options=
+CH32V00x_EVT.menu.upload_method.wlinkMethod.upload.tool=wlink
 
 
 # Clock Select
@@ -382,6 +440,10 @@ CH32VM00X_EVT.menu.upload_method.ispMethod=WCH-ISP
 CH32VM00X_EVT.menu.upload_method.ispMethod.upload.protocol=
 CH32VM00X_EVT.menu.upload_method.ispMethod.upload.options=
 CH32VM00X_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
+CH32VM00X_EVT.menu.upload_method.wlinkMethod=WCH-Link (wlink)
+CH32VM00X_EVT.menu.upload_method.wlinkMethod.upload.protocol=
+CH32VM00X_EVT.menu.upload_method.wlinkMethod.upload.options=
+CH32VM00X_EVT.menu.upload_method.wlinkMethod.upload.tool=wlink
 
 
 # Clock Select
@@ -486,6 +548,10 @@ CH32X035_EVT.menu.upload_method.ispMethod=WCH-ISP
 CH32X035_EVT.menu.upload_method.ispMethod.upload.protocol=
 CH32X035_EVT.menu.upload_method.ispMethod.upload.options=
 CH32X035_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
+CH32X035_EVT.menu.upload_method.wlinkMethod=WCH-Link (wlink)
+CH32X035_EVT.menu.upload_method.wlinkMethod.upload.protocol=
+CH32X035_EVT.menu.upload_method.wlinkMethod.upload.options=
+CH32X035_EVT.menu.upload_method.wlinkMethod.upload.tool=wlink
 
 
 # Clock Select
@@ -589,6 +655,10 @@ CH32V10x_EVT.menu.upload_method.ispMethod=WCH-ISP
 CH32V10x_EVT.menu.upload_method.ispMethod.upload.protocol=
 CH32V10x_EVT.menu.upload_method.ispMethod.upload.options=
 CH32V10x_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
+CH32V10x_EVT.menu.upload_method.wlinkMethod=WCH-Link (wlink)
+CH32V10x_EVT.menu.upload_method.wlinkMethod.upload.protocol=
+CH32V10x_EVT.menu.upload_method.wlinkMethod.upload.options=
+CH32V10x_EVT.menu.upload_method.wlinkMethod.upload.tool=wlink
 
 
 # Clock Select
@@ -785,6 +855,10 @@ CH32V20x_EVT.menu.upload_method.ispMethod=WCH-ISP
 CH32V20x_EVT.menu.upload_method.ispMethod.upload.protocol=
 CH32V20x_EVT.menu.upload_method.ispMethod.upload.options=
 CH32V20x_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
+CH32V20x_EVT.menu.upload_method.wlinkMethod=WCH-Link (wlink)
+CH32V20x_EVT.menu.upload_method.wlinkMethod.upload.protocol=
+CH32V20x_EVT.menu.upload_method.wlinkMethod.upload.options=
+CH32V20x_EVT.menu.upload_method.wlinkMethod.upload.tool=wlink
 
 
 # Clock Select
@@ -913,6 +987,10 @@ CH32V30x_EVT.menu.upload_method.ispMethod=WCH-ISP
 CH32V30x_EVT.menu.upload_method.ispMethod.upload.protocol=
 CH32V30x_EVT.menu.upload_method.ispMethod.upload.options=
 CH32V30x_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
+CH32V30x_EVT.menu.upload_method.wlinkMethod=WCH-Link (wlink)
+CH32V30x_EVT.menu.upload_method.wlinkMethod.upload.protocol=
+CH32V30x_EVT.menu.upload_method.wlinkMethod.upload.options=
+CH32V30x_EVT.menu.upload_method.wlinkMethod.upload.tool=wlink
 
 
 # Clock Select
@@ -1033,6 +1111,10 @@ CH32L10x_EVT.menu.upload_method.ispMethod=WCH-ISP
 CH32L10x_EVT.menu.upload_method.ispMethod.upload.protocol=
 CH32L10x_EVT.menu.upload_method.ispMethod.upload.options=
 CH32L10x_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
+CH32L10x_EVT.menu.upload_method.wlinkMethod=WCH-Link (wlink)
+CH32L10x_EVT.menu.upload_method.wlinkMethod.upload.protocol=
+CH32L10x_EVT.menu.upload_method.wlinkMethod.upload.options=
+CH32L10x_EVT.menu.upload_method.wlinkMethod.upload.tool=wlink
 
 
 # Clock Select
@@ -1105,4 +1187,3 @@ CH32L10x_EVT.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
 CH32L10x_EVT.menu.rtlib.nanofps.build.flags.ldflags=--specs=nano.specs --specs=nosys.specs -u _printf_float -u _scanf_float
 CH32L10x_EVT.menu.rtlib.full=Newlib Standard
 CH32L10x_EVT.menu.rtlib.full.build.flags.ldflags=--specs=nosys.specs
-

--- a/package_ch32v_index_release.json
+++ b/package_ch32v_index_release.json
@@ -53,6 +53,11 @@
                         },
                         {
                             "packager": "WCH",
+                            "name": "wlink",
+                            "version": "0.1.1"
+                        },
+                        {
+                            "packager": "WCH",
                             "name": "beforeinstall",
                             "version": "1.0.0"
                         }
@@ -490,6 +495,33 @@
                             "archiveFileName": "wchisp-macos-x64_20251008.zip",
                             "checksum": "SHA-256:f9da872724def1ed8914b89764dc6b67ce3c577662e2f5335e63a9e173b63136",
                             "size": "868868"
+                        }
+                    ]
+                },
+                {
+                    "name": "wlink",
+                    "version": "0.1.1",
+                    "systems": [
+                        {
+                            "host": "x86_64-linux-gnu",
+                            "url": "https://github.com/ch32-rs/wlink/releases/download/v0.1.1/wlink-v0.1.1-linux-x64.tar.gz",
+                            "archiveFileName": "wlink-v0.1.1-linux-x64.tar.gz",
+                            "checksum": "SHA-256:5bdef80440832f696578c0eb43f79c3819fc3fba19d37fd51374144bb86f3c6a",
+                            "size": "846537"
+                        },
+                        {
+                            "host": "i686-mingw32",
+                            "url": "https://github.com/ch32-rs/wlink/releases/download/v0.1.1/wlink-v0.1.1-win-x86.zip",
+                            "archiveFileName": "wlink-v0.1.1-win-x86.zip",
+                            "checksum": "SHA-256:263c0fe47ed12a784cab96bed1f0805b450bf77b174c1fe2dc2319ea2992341e",
+                            "size": "586947"
+                        },
+                        {
+                            "host": "x86_64-apple-darwin",
+                            "url": "https://github.com/ch32-rs/wlink/releases/download/v0.1.1/wlink-v0.1.1-macos-x64.tar.gz",
+                            "archiveFileName": "wlink-v0.1.1-macos-x64.tar.gz",
+                            "checksum": "SHA-256:fe5e4c3a38f367fcd56a8b77ec8f7ffcca67e50315d8e69e6ce50d9e9862fa3b",
+                            "size": "747481"
                         }
                     ]
                 },

--- a/package_ch32v_index_template.json
+++ b/package_ch32v_index_template.json
@@ -53,6 +53,11 @@
                         },
                         {
                             "packager": "WCH",
+                            "name": "wlink",
+                            "version": "0.1.1"
+                        },
+                        {
+                            "packager": "WCH",
                             "name": "beforeinstall",
                             "version": "1.0.0"
                         }
@@ -219,6 +224,33 @@
                             "archiveFileName": "wchisp-macos-x64_20251101.zip",
                             "checksum": "SHA-256:7777f2aa3e9810a2ff8d352346210c77af5fabfeb0be3b85f30f21c4364bec7a",
                             "size": "868994"
+                        }
+                    ]
+                },
+                {
+                    "name": "wlink",
+                    "version": "0.1.1",
+                    "systems": [
+                        {
+                            "host": "x86_64-linux-gnu",
+                            "url": "https://github.com/ch32-rs/wlink/releases/download/v0.1.1/wlink-v0.1.1-linux-x64.tar.gz",
+                            "archiveFileName": "wlink-v0.1.1-linux-x64.tar.gz",
+                            "checksum": "SHA-256:5bdef80440832f696578c0eb43f79c3819fc3fba19d37fd51374144bb86f3c6a",
+                            "size": "846537"
+                        },
+                        {
+                            "host": "i686-mingw32",
+                            "url": "https://github.com/ch32-rs/wlink/releases/download/v0.1.1/wlink-v0.1.1-win-x86.zip",
+                            "archiveFileName": "wlink-v0.1.1-win-x86.zip",
+                            "checksum": "SHA-256:263c0fe47ed12a784cab96bed1f0805b450bf77b174c1fe2dc2319ea2992341e",
+                            "size": "586947"
+                        },
+                        {
+                            "host": "x86_64-apple-darwin",
+                            "url": "https://github.com/ch32-rs/wlink/releases/download/v0.1.1/wlink-v0.1.1-macos-x64.tar.gz",
+                            "archiveFileName": "wlink-v0.1.1-macos-x64.tar.gz",
+                            "checksum": "SHA-256:fe5e4c3a38f367fcd56a8b77ec8f7ffcca67e50315d8e69e6ce50d9e9862fa3b",
+                            "size": "747481"
                         }
                     ]
                 },

--- a/platform.txt
+++ b/platform.txt
@@ -179,6 +179,14 @@ tools.wchisp.upload.params.verbose=
 tools.wchisp.upload.params.quiet=
 tools.wchisp.upload.pattern="{path}{cmd}" {upload.verbose} --retry 2 flash "{build.path}/{build.project_name}.elf"
 
+## wlink (WCH-Link)
+tools.wlink.path={runtime.tools.wlink.path}/
+tools.wlink.cmd=wlink
+tools.wlink.cmd.windows=wlink.exe
+tools.wlink.upload.params.verbose=
+tools.wlink.upload.params.quiet=
+tools.wlink.upload.pattern="{path}{cmd}" {upload.verbose} flash -e "{build.path}/{build.project_name}.elf"
+
 
 # Debugger configuration (general options)
 # ----------------------------------------

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -195,6 +195,12 @@ def build_upload(series, values):
     print(f'{menu_isp}.upload.options=')
     print(f'{menu_isp}.upload.tool=wchisp')
 
+    menu_wlink = f'{menu}.wlinkMethod'
+    print(f'{menu_wlink}=WCH-Link (wlink)')
+    print(f'{menu_wlink}.upload.protocol=')
+    print(f'{menu_wlink}.upload.options=')
+    print(f'{menu_wlink}.upload.tool=wlink')
+
     print()
 
 


### PR DESCRIPTION
This PR adds WCH-Link (wlink) as a new upload method in the CH32 Arduino core

## What’s included
Added a new uploader tool in platform.txt:
tools.wlink.*
upload recipe: wlink flash -e "{build.path}/{build.project_name}.elf"
## Exposed wlink in Tools > Upload Method as:
WCH-Link (wlink)
Kept WCH-SWD as the default upload method (no behavior change for existing users).
Updated board generation logic (tools/makeboards.py) and regenerated boards.txt.
Added wlink tool dependency in package index files (Boards Manager delivery).
Kept programmers.txt unchanged (out of scope).

## Adjusted CH573 upload-touch behavior:
wlinkMethod: upload.use_1200bps_touch=false
swdMethod: upload.use_1200bps_touch=false
ispMethod: upload.use_1200bps_touch=true
## Validation
arduino-cli board details shows wlinkMethod in upload options.
Compile succeeds for target boards (including CH573).
Upload command resolves correctly to wlink flash -e <firmware>.elf.
On hardware, wlink can attach and flash CH573 when debug link is active.


